### PR TITLE
fix: depth-awareness headers in generated markdown

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -27,7 +27,7 @@ func TestMarkdownGeneratorProducesMarkdownForClass(t *testing.T) {
 	markdown := GenerateMarkdown(ast)
 
 	expectedMarkdown := `# sample.ts
-### MyClass
+## MyClass
 /* Leading Comment */
 ### method
 /* Method Leading Comment */`

--- a/internal/generator/main.go
+++ b/internal/generator/main.go
@@ -6,35 +6,43 @@ import (
 	"strings"
 )
 
-type ForEachChild func(parser.Node)
+type ForEachChild func(parser.Node, int)
 
-var Traverse func(parser.Node, ForEachChild)
+var Traverse func(parser.Node, ForEachChild, int)
 
 // Generates a Markdown document from the provided
 // ast.
 func GenerateMarkdown(ast parser.Node) string {
-	Traverse = func(ast parser.Node, fn ForEachChild) {
-		fn(ast)
+	Traverse = func(ast parser.Node, fn ForEachChild, depth int) {
+		fn(ast, depth)
 
 		for _, child := range ast.Children {
-			Traverse(child, fn)
+			Traverse(child, fn, depth+1)
 		}
 	}
 
 	document := []string{fmt.Sprintf("# %s", ast.Identifier)}
 
-	forEachChild := func(node parser.Node) {
+	forEachChild := func(node parser.Node, depth int) {
 		leadingComment := ""
 
 		if len(node.LeadingComments) > 0 {
 			leadingComment = node.LeadingComments[0]
 		}
 
-		document = append(document, ([]string{"### " + node.Identifier, leadingComment})...)
+		var headingPrefix string
+
+		if depth < 3 {
+			headingPrefix = strings.Repeat("#", 1+depth)
+		} else {
+			headingPrefix = "###"
+		}
+
+		document = append(document, ([]string{fmt.Sprintf("%s %s", headingPrefix, node.Identifier), leadingComment})...)
 	}
 
 	for _, child := range ast.Children {
-		Traverse(child, forEachChild)
+		Traverse(child, forEachChild, 1)
 	}
 
 	return strings.Join(document, "\n")


### PR DESCRIPTION
- Adds some depth-awareness to the headers in generated markdown based on the depth of the node being represented.